### PR TITLE
Use list variable to set source_ips for LB

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ resource "google_compute_firewall" "default-lb-fw" {
     ports    = [var.service_port]
   }
 
-  source_ranges = ["0.0.0.0/0"]
+  source_ranges = var.allowed_ips
 
   target_tags = var.target_tags
 

--- a/variables.tf
+++ b/variables.tf
@@ -102,3 +102,9 @@ variable "ip_protocol" {
   description = "The IP protocol for the frontend forwarding rule and firewall rule. TCP, UDP, ESP, AH, SCTP or ICMP."
   default     = "TCP"
 }
+
+variable "allowed_ips" {
+  description = "The IP address ranges which can access the load balancer."
+  default     = ["0.0.0.0/0"]
+
+}


### PR DESCRIPTION
Instead of hardcoding source_ip ranges into the to module, make use of
variable.

Create a new variable with name `allowed_ips` with the default set to
`[0.0.0.0/0]`.  This change allows the user to restrict access to
external load balancer from only from a small set of ip addresses.